### PR TITLE
Attempt to reproduce without concurrency limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 ### `pull_request.labeled` events sometimes missing from PR check summary view
 
 - https://github.com/urcomputeringpal/actions-bug-repros/pull/2
+


### PR DESCRIPTION
This PR shows two comments from two invocations of the "concurrent pr labels" workflow, but only one appears below in the mergeability detail view:

<img width="822" alt="image" src="https://github.com/urcomputeringpal/actions-bug-repros/assets/47/6f9a3b21-d628-409d-bf61-324c4148ee8a">
